### PR TITLE
Jekyll issues a deprecation warning for the _config.yml file stating:…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ exclude:
   - site-tools
   - "*/tmp.*"
 
-gems:
+plugins:
   - jekyll-mentions
   - jekyll-redirect-from
 


### PR DESCRIPTION
… "Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly."

I'm just updating as suggested, the change is not needed during a full merge.