### PR TITLE
Adding Graphviz Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ group :development do
   gem 'github-pages',
   group: :jekyll_plugins
 end
+
+group :jekyll_plugins do
+  gem 'jekyll_graphviz'
+end

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ The website runs under Github pages, which runs Jekyll.
 
 The main repository for this repo is https://github.com/niem/niem.github.io/.
 
+## Dependencies
+
+* Ruby
+  * Jekyll
+  * Bundler
+* Graphviz
+
 ## Installation
 
 Run the following from a Unix-like command line:
@@ -15,7 +22,8 @@ $ git clone https://github.com/niem/niem.github.io.git
 $ cd niem.github.io
 $ git submodule init
 $ git submodule update
-$ jekyll serve
+$ bundle install
+$ bundle exec jekyll serve
 ```
 
 Point your browser at http://127.0.0.1:4000 to view the site.


### PR DESCRIPTION
Adding a Graphviz dependency to the NIEM documentation site. We'd like to create Graphviz graphics inline in the site code without rendering in a separate program. There is a plugin specified in the Gemfile for the Jekyll/Graphviz interface using the Graphviz-dot program.

Made  a small modification to the GitHub pages README file to directly specify that this project depends on Ruby and GraphViz being installed on the hosting machine; as well as fixing the commands to run the site from your local machine through bundler.